### PR TITLE
Fix example homepage by updating CDN and tile URLs

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,9 +4,9 @@
     <meta charset=utf-8 />
     <meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, minimal-ui' />
     <title>Leaflet Side-by-side</title>
-    <script src='http://cdn.leafletjs.com/leaflet/v1.3.1/leaflet.js'></script>
+    <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
     <script src="leaflet-side-by-side.js"></script>
-    <link href='http://cdn.leafletjs.com/leaflet/v1.3.1/leaflet.css' rel='stylesheet' />
+    <link href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" rel="stylesheet" />
     <style>
     body {
         margin: 0;
@@ -27,14 +27,14 @@
     <script>
     var map = L.map('map').setView([51.505, -0.09], 13);
 
-    var osmLayer = L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap<\/a> contributors'
+    var osmLayer = L.tileLayer('https://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+        attribution: '&copy; <a href="https://osm.org/copyright">OpenStreetMap<\/a> contributors'
     }).addTo(map);
 
-    var stamenLayer = L.tileLayer('https://stamen-tiles-{s}.a.ssl.fastly.net/watercolor/{z}/{x}/{y}.png', {
+    var stamenLayer = L.tileLayer('https://tiles.stadiamaps.com/tiles/stamen_watercolor/{z}/{x}/{y}.jpg', {
         attribution:
-            'Map tiles by <a href="http://stamen.com">Stamen Design<\/a>, ' +
-            '<a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0<\/a> &mdash; ' +
+            'Map tiles by <a href="https://stamen.com">Stamen Design<\/a>, ' +
+            '<a href="https://creativecommons.org/licenses/by/3.0">CC BY 3.0<\/a> &mdash; ' +
             'Map data {attribution.OpenStreetMap}',
         minZoom: 1,
         maxZoom: 16


### PR DESCRIPTION
The current homepage example site at https://lab.digital-democracy.org/leaflet-side-by-side/ is broken for various reasons - links have been removed, Leaflet no longer hosts its own CDN, and Stamen have moved their tiles to Stadia.

This PR updates those URLs, including updating to `https://`. The updated homepage now works again, and can be seen at https://davidjb.github.io/leaflet-side-by-side/.